### PR TITLE
updated login flow and added auth request headers

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,9 +1,10 @@
 /**
  *      Imports & configuration
  *
-/** 1 REACT */
-import React from "react"
-import { StyleSheet, Text, View } from "react-native"
+/** 1 REACT (NATIVE) */
+import React, { useEffect, useState } from "react"
+import { StyleSheet } from "react-native"
+
 /** 2 NAVIGATION */
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
@@ -19,51 +20,109 @@ import WelcomeScreen from "./src/screens/Welcome"
 const Tab = createBottomTabNavigator()
 const Stack = createStackNavigator()
 
-/** 3 APOLLOCLIENT  */
+/** 3 Apollo Client with authentication 'middleware' */
+// import * as SecureStore from "expo-secure-store  // this package should provide more secure storage than Async but is not working for some reason
+import AsyncStorage from "@react-native-community/async-storage"
+import { setContext } from "@apollo/client/link/context"
 import {
   ApolloProvider,
   ApolloClient,
   InMemoryCache,
   createHttpLink,
 } from "@apollo/client"
+
+const authLink = setContext(async (_, { headers }) => {
+  // get the authentication token from local storage if it exists
+  const token = await AsyncStorage.getItem("token")
+
+  // return the headers to the context so httpLink can read them
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : "",
+    },
+  }
+})
+
 const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link: createHttpLink({ uri: "http://192.168.178.18:4000/graphql" }),
+  link: authLink.concat(
+    createHttpLink({ uri: "http://192.168.178.18:4000/graphql" })
+  ),
 })
+
+/** 5 REDUX STORE */
+import { Provider, useSelector, useDispatch } from "react-redux"
+import { selectUser } from "./src/store/user/selectors"
+import store from "./src/store"
 
 /**************************************************************************************************************************************************************************/
 /** TO DO:
- * Review Navigation: choose whether and if so how to nest the navigation. List & Map are definitely tabs, and can maybe be nested in Home. Where to add settings/profile..
  * Add a loading screen that is displayed while checking for a token in Asyncstorage
- * Work out the isSignedIn logic => add token verification
+ * See if App updates based on isSignedIn if we go through Async storage (so without passing down callback setSignedIn)
  */
 
 /**
- *     Our App
+ *     App
  */
+
 export default function App() {
+  // const [isSignedIn, setSignedIn] = useState(false)
+
+  // useEffect(() => {
+  //   async function getToken() {
+  //     const token = await AsyncStorage.getItem("token")
+  //     console.log("token in App.js useEffect:", token)
+  //     if (token) {
+  //       setSignedIn(true)
+  //     }
+  //   }
+  //   getToken()
+  // }, [])
+
+  const isSignedIn = AsyncStorage.getItem("token")
+  console.log("signed in?", isSignedIn)
+
   return (
-    <ApolloProvider client={client}>
-      <NavigationContainer>
-        {/* isSignedIn ? ( */}
+    <Provider store={store}>
+      <ApolloProvider client={client}>
+        {/* <NavigationContainer> */}
+        {/* <Stack.Navigator initialRouteName="List"> */}
         {/* <Tab.Navigator initialRouteName="Home"> */}
         {/* <Tab.Screen name="Home" component={HomeScreen} /> */}
         {/* <Tab.Screen name="Profile" component={ProfileScreen} /> */}
-        {/* <Tab.Screen name="List" component={ListScreen} /> */}
         {/* <Tab.Screen name="Map" component={MapScreen} /> */}
         {/* </Tab.Navigator> */}
-        {/* ) : ( */}
-        <Stack.Navigator initialRouteName="List">
-          <Stack.Screen name="List" component={ListScreen} />
-          <Stack.Screen name="Welcome" component={WelcomeScreen} />
-          <Stack.Screen name="Sign up" component={SignUpScreen} />
-          <Stack.Screen name="Log in" component={LoginScreen} />
-        </Stack.Navigator>
-        {/* ) */}
-      </NavigationContainer>
-    </ApolloProvider>
+        {/* </Stack.Navigator> */}
+        {/* </NavigationContainer> */}
+        <NavigationContainer>
+          <Stack.Navigator initialRouteName="Welcome">
+            {isSignedIn ? (
+              <>
+                <Stack.Screen name="List" component={ListScreen} />
+              </>
+            ) : (
+              <>
+                <Stack.Screen name="Welcome" component={WelcomeScreen} />
+                <Stack.Screen name="Sign up" component={SignUpScreen} />
+                <Stack.Screen
+                  name="Log in"
+                  component={(props) => (
+                    <LoginScreen {...props} setSignedIn={setSignedIn} />
+                  )}
+                />
+              </>
+            )}
+          </Stack.Navigator>
+        </NavigationContainer>
+      </ApolloProvider>
+    </Provider>
   )
 }
+
+/**
+ *     Styling
+ */
 
 const styles = StyleSheet.create({
   container: {

--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -1,22 +1,33 @@
 import React, { useState } from "react"
 import { View, Text, Image, TextInput, Button, StyleSheet } from "react-native"
-import { useMutation, gql } from "@apollo/client"
-import { LOGIN } from "../queries/queries"
+import { useMutation, useQuery, gql } from "@apollo/client"
+import { LOGIN, CURRENTUSER } from "../queries/queries"
+import * as SecureStore from "expo-secure-store"
+import AsyncStorage from "@react-native-community/async-storage"
 
-export default function LoginScreen({ navigation }) {
+export default function LoginScreen({ navigation, setSignedIn }) {
   const [email, setEmail] = useState("test@mail.com")
   const [password, setPassword] = useState("123")
-  const [Login, { data }] = useMutation(LOGIN)
+  const [Login, data] = useMutation(LOGIN)
+
+  console.log("@login", data)
 
   const handleLogin = async (e) => {
     e.preventDefault()
     try {
-      Login({ variables: { email: email, password: password } })
-    } catch (error) {
-      console.log("error:", error)
+      await Login({ variables: { email: email, password: password } })
+      // SecureStore.setItemAsync(loggedIn, data)
+      console.log("data after login attempt", data)
+      await AsyncStorage.setItem("token", data.login)
+      setSignedIn(true)
+    } catch (e) {
+      console.log("error:", e)
     }
     // CLEAR DATA FROM INPUT FIELDS?
   }
+
+  // const user = useQuery(CURRENTUSER)
+  // console.log("User", user)
 
   return (
     <View style={styles.form}>

--- a/src/screens/SignUp.js
+++ b/src/screens/SignUp.js
@@ -18,19 +18,20 @@ export default function SignUpScreen({ navigation }) {
    *  App state management
    */
   const [message, setMessage] = useState("")
-  const [loading, setLoading] = useState(false)
 
   /**
    *  Handlers
    */
-  const [SignUp] = useMutation(SIGNUP)
-  const handleSignUp = (e) => {
+  const [SignUp, { loading, error, data }] = useMutation(SIGNUP)
+
+  const handleSignUp = async (e) => {
     e.preventDefault()
     if (!name || !email || !password || !address || !gender) {
       setMessage("Please fill in all the required fields")
     } else
       try {
-        SignUp({ variables: { name, email, password, address, gender } })
+        await SignUp({ variables: { name, email, password, address, gender } })
+        console.log("data@signup", data)
       } catch (e) {
         console.log("error:", e)
       }
@@ -43,7 +44,6 @@ export default function SignUpScreen({ navigation }) {
     <View style={styles.container}>
       <Text style={styles.heading}>Sign up</Text>
       <Text>{message}</Text>
-      <Text>{loading}</Text>
       <View style={styles.form}>
         <TextInput
           style={styles.input}


### PR DESCRIPTION
This pull request adds:

- Authlink to Apollo Client so that we send along auth headers on requests to the GraphQL server
- isSignedIn as local state in App.js 
- setIsSignedIn as callback prop, sent to Login Screen (may cause performance issues so looking for alternative)