### PR TITLE
separated some cofig of the app & added AuthProvider

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import { ActivityIndicator, StyleSheet, View } from "react-native"
 /** 2 NAVIGATION */
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
+import CreateActivityScreen from "./src/screens/CreateActivity"
 import LoginScreen from "./src/screens/Login"
 import SignUpScreen from "./src/screens/SignUp"
 import WelcomeScreen from "./src/screens/Welcome"
@@ -17,52 +18,13 @@ const Stack = createStackNavigator()
 
 /** 3 Apollo Client with authentication 'middleware' */
 import AsyncStorage from "@react-native-community/async-storage"
-import { cache, isSignedInVar } from "./src/cache"
-import { CURRENTUSER } from "./src/queries/queries"
-import { setContext } from "@apollo/client/link/context"
-import {
-  ApolloProvider,
-  ApolloClient,
-  InMemoryCache,
-  createHttpLink,
-  useQuery,
-  makeVar,
-  useReactiveVar,
-} from "@apollo/client"
+import { theme, client, isSignedInVar } from "./src/config"
+import { ApolloProvider, useReactiveVar } from "@apollo/client"
 
 /** Setting up authLink so we send along auth headers with our requests to GraphQL */
 
-const authLink = setContext(async (_, { headers }) => {
-  // get the authentication token from local storage if it exists
-  const token = await AsyncStorage.getItem("token")
-
-  // return the headers to the context so httpLink can read them
-  return {
-    headers: {
-      ...headers,
-      authorization: token ? `Bearer ${token}` : "",
-    },
-  }
-})
-
-export const client = new ApolloClient({
-  cache: cache,
-  link: authLink.concat(
-    createHttpLink({ uri: "http://192.168.178.18:4000/graphql" })
-  ),
-})
 /** 4 Styling: Paper Material UI */
-import { DefaultTheme, Provider as PaperProvider } from "react-native-paper"
-import CreateActivityScreen from "./src/screens/CreateActivity"
-
-const theme = {
-  ...DefaultTheme,
-  colors: {
-    ...DefaultTheme.colors,
-    primary: "tomato",
-    accent: "yellow",
-  },
-}
+import { Provider as PaperProvider } from "react-native-paper"
 
 /**************************************************************************************************************************************************************************/
 /**
@@ -73,12 +35,12 @@ export default function App() {
   const [loading, setLoading] = useState(true)
   const isSignedIn = useReactiveVar(isSignedInVar)
 
-  // Check if the user is logged in or not
+  // Check if there's still a valid token in local storage
   useEffect(() => {
     async function getToken() {
       const token = await AsyncStorage.getItem("token")
       if (token) {
-        console.log("token in App.js auth check:", token)
+        // console.log("token found in App.js auth check:", token)
         isSignedInVar(true)
         setLoading(false)
       } else {
@@ -114,11 +76,19 @@ export default function App() {
               <>
                 <Stack.Screen
                   name="Welcome"
-                  options={{ header: () => null }}
+                  options={{}}
                   component={WelcomeScreen}
                 />
-                <Stack.Screen name="Sign up" component={SignUpScreen} />
-                <Stack.Screen name="Log in" component={LoginScreen} />
+                <Stack.Screen
+                  name="Sign up"
+                  screenOptions={{ header: () => null }}
+                  component={SignUpScreen}
+                />
+                <Stack.Screen
+                  name="Log in"
+                  screenOptions={{ header: () => null }}
+                  component={LoginScreen}
+                />
               </>
             )}
           </Stack.Navigator>

--- a/src/AuthProvider.js
+++ b/src/AuthProvider.js
@@ -1,0 +1,44 @@
+import React, { createContext, useState } from "react"
+import { View, Text } from "react-native"
+
+export const AuthContext = createContext({})
+
+export default function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+  const [Login, { data }] = useMutation(LOGIN, {
+    onCompleted: (data) => {
+      AsyncStorage.setItem("token", data.login)
+      isSignedInVar(true)
+    },
+  })
+
+
+
+  return <AuthContext.Provider value={{
+    user,
+    login: () => {
+      try {
+        await Login({ variables: { email: email, password: password } })
+      } catch (e) {
+        console.log("error:", e)
+      }
+      
+    },
+    logout: () => {
+      asy
+    }
+  }}>
+{children}
+  </AuthContext.Provider>
+}
+
+
+  const logout = async () => {
+    await AsyncStorage.removeItem("token")
+    isSignedInVar(false)
+  }
+
+
+
+  const handleLogin = async (e) => {
+  }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,54 @@
+import {
+  ApolloClient,
+  createHttpLink,
+  InMemoryCache,
+  makeVar,
+} from "@apollo/client"
+import { setContext } from "@apollo/client/link/context"
+import AsyncStorage from "@react-native-community/async-storage"
+import { DefaultTheme } from "react-native-paper"
+
+export const isSignedInVar = makeVar()
+
+const cache = new InMemoryCache({
+  typePolicies: {
+    Query: {
+      fields: {
+        isSignedIn: {
+          read() {
+            return isSignedInVar()
+          },
+        },
+      },
+    },
+  },
+})
+
+const authLink = setContext(async (_, { headers }) => {
+  // get the authentication token from local storage if it exists
+  const token = await AsyncStorage.getItem("token")
+
+  // return the headers to the context so httpLink can read them
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : "",
+    },
+  }
+})
+
+export const client = new ApolloClient({
+  cache: cache,
+  link: authLink.concat(
+    createHttpLink({ uri: "http://192.168.178.18:4000/graphql" })
+  ),
+})
+
+export const theme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: "#FF521B",
+    accent: "#ACE4AA",
+  },
+}


### PR DESCRIPTION
This PR adds

- an AuthProvider to the app, which gives access to login / logout and the current user through a useContext hook.
- Login now works with Apollo's cache in combination with a reactive variable. 
- an authlink that passes the token if there is one as request header, so I can set up Authorization in the back end. 
- some refactoring of the App, for example some of the configuration logic is moved to a separate file. 
- rearranged the navigation stacks to make things a bit cleaner

Things to consider for a future update:

- options passed to the navigation stacks don't seem to have an effect.
- the division between things that run through useContext and the Apollo cache needs reviewing at a later stage
- pick some theme colours